### PR TITLE
feat(echoflow-api): EchoFlow API 安全修复与编辑历史支持

### DIFF
--- a/src/app/api/echoflow/[...path]/route.ts
+++ b/src/app/api/echoflow/[...path]/route.ts
@@ -219,7 +219,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     const corsHeaders = buildCorsHeaders(origin);
     const securityHeaders = {
-      'Vary': 'Origin',
+      Vary: 'Origin',
       'X-Content-Type-Options': 'nosniff',
     };
 
@@ -281,7 +281,7 @@ export async function OPTIONS(request: NextRequest) {
       'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-EchoFlow-Key',
       'Cache-Control': 'public, max-age=86400',
       'X-EchoFlow-Health': 'healthy',
-      'Vary': 'Origin',
+      Vary: 'Origin',
       'X-Content-Type-Options': 'nosniff',
     },
   });

--- a/src/app/api/echoflow/[...path]/route.ts
+++ b/src/app/api/echoflow/[...path]/route.ts
@@ -3,6 +3,7 @@
  *
  */
 
+import { timingSafeEqual } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { cached } from '@/lib/serverCache';
@@ -128,7 +129,11 @@ function isOriginAllowed(origin: string | null): boolean {
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const origin = request.headers.get('origin');
   const clientKey = request.headers.get(API_KEY_HEADER);
-  const hasValidKey = FLOW_KEY && clientKey === FLOW_KEY;
+
+  let hasValidKey = false;
+  if (FLOW_KEY && clientKey && clientKey.length === FLOW_KEY.length) {
+    hasValidKey = timingSafeEqual(Buffer.from(clientKey), Buffer.from(FLOW_KEY));
+  }
 
   if (!FLOW_KEY) {
     return NextResponse.json(
@@ -221,6 +226,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const securityHeaders = {
       Vary: 'Origin',
       'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     };
 
     if (format === 'jsonl') {
@@ -265,7 +272,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 export async function OPTIONS(request: NextRequest) {
   const origin = request.headers.get('origin');
   const clientKey = request.headers.get(API_KEY_HEADER);
-  const hasValidKey = FLOW_KEY && clientKey === FLOW_KEY;
+
+  let hasValidKey = false;
+  if (FLOW_KEY && clientKey && clientKey.length === FLOW_KEY.length) {
+    hasValidKey = timingSafeEqual(Buffer.from(clientKey), Buffer.from(FLOW_KEY));
+  }
 
   if (!isOriginAllowed(origin) && !hasValidKey) {
     return new NextResponse(null, { status: 403 });
@@ -283,6 +294,8 @@ export async function OPTIONS(request: NextRequest) {
       'X-EchoFlow-Health': 'healthy',
       Vary: 'Origin',
       'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
   });
 }

--- a/src/app/api/echoflow/[...path]/route.ts
+++ b/src/app/api/echoflow/[...path]/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { cached } from '@/lib/serverCache';
+import { env } from '@/env';
 
 import { resolvePath } from '../resolvers';
 
@@ -74,11 +75,14 @@ function decodePathSegments(segments: string[]): string[] {
 }
 
 const API_KEY_HEADER = 'X-EchoFlow-Key';
-const FLOW_KEY = process.env.FLOWKEY;
+const FLOW_KEY = env.FLOWKEY;
 
 function buildCorsHeaders(origin: string | null): Record<string, string> {
+  if (!origin || !isOriginAllowed(origin)) {
+    return {};
+  }
   return {
-    'Access-Control-Allow-Origin': origin || '*',
+    'Access-Control-Allow-Origin': origin,
   };
 }
 
@@ -106,10 +110,16 @@ function isOriginAllowed(origin: string | null): boolean {
   if (!origin) return false;
 
   try {
-    const originHostname = new URL(origin).hostname;
-    return TRUSTED_HOSTNAMES.some(
-      (trusted) => originHostname === trusted || originHostname.endsWith(`.${trusted}`)
-    );
+    const url = new URL(origin);
+    const originHostname = url.hostname;
+    return TRUSTED_HOSTNAMES.some((trusted) => {
+      if (originHostname === trusted) return true;
+      if (originHostname.endsWith(`.${trusted}`)) {
+        const subdomain = originHostname.slice(0, -(trusted.length + 1));
+        return /^[a-zA-Z0-9]+$/.test(subdomain);
+      }
+      return false;
+    });
   } catch {
     return false;
   }
@@ -123,7 +133,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (!FLOW_KEY) {
     return NextResponse.json(
       { error: 'EchoFlow API is not enabled', code: 'SERVICE_DISABLED' },
-      { status: 503, headers: buildCorsHeaders(origin) }
+      { status: 503 }
     );
   }
 
@@ -131,7 +141,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     if (!isOriginAllowed(origin)) {
       return NextResponse.json(
         { error: 'origin not allowed', code: 'ORIGIN_FORBIDDEN' },
-        { status: 403, headers: buildCorsHeaders(origin) }
+        { status: 403 }
       );
     }
     return NextResponse.json(
@@ -157,24 +167,20 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     );
   }
 
-  const detailId =
-    pathSegments.length > 1 ? sanitizeDetailId(pathSegments.slice(1).join('/')) : undefined;
-
   function sanitizeDetailId(id: string): string | undefined {
     if (!id || id.length === 0) return undefined;
     const decoded = id.replace(/%2f/gi, '/').replace(/\\/g, '/');
-    if (decoded.includes('..') || decoded.includes('%')) {
+    if (decoded.includes('..')) {
       return undefined;
     }
-    for (let i = 0; i < decoded.length; i++) {
-      const charCode = decoded.charCodeAt(i);
-      const char = decoded.charAt(i);
-      if (charCode < 0x20 || '<>\'"\\'.includes(char)) {
-        return undefined;
-      }
+    if (decoded.length > MAX_DETAIL_ID_LENGTH) {
+      return undefined;
     }
-    return decoded.slice(0, MAX_DETAIL_ID_LENGTH);
+    return decoded;
   }
+
+  const detailId =
+    pathSegments.length > 1 ? sanitizeDetailId(pathSegments.slice(1).join('/')) : undefined;
 
   const firstSegment = pathSegments[0];
   if (!firstSegment) {
@@ -190,13 +196,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(
       { error: 'Resource type not found', code: 'TYPE_NOT_FOUND', resourceType },
       { status: 404, headers: buildCorsHeaders(origin) }
-    );
-  }
-
-  if (detailId !== undefined && sanitizeDetailId(detailId) === undefined) {
-    return NextResponse.json(
-      { error: 'Invalid detail ID', code: 'INVALID_DETAIL_ID' },
-      { status: 400, headers: buildCorsHeaders(origin) }
     );
   }
 
@@ -218,7 +217,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const responseData =
       result && typeof result === 'object' && 'data' in result ? result : { data: result };
 
-    const healthStatus = FLOW_KEY ? 'healthy' : 'disabled';
+    const corsHeaders = buildCorsHeaders(origin);
+    const securityHeaders = {
+      'Vary': 'Origin',
+      'X-Content-Type-Options': 'nosniff',
+    };
 
     if (format === 'jsonl') {
       const jsonlContent = toJsonl(responseData.data);
@@ -227,8 +230,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         headers: {
           'Content-Type': 'application/jsonl',
           'Cache-Control': `public, max-age=${getCacheTtl(resourceType)}, stale-while-revalidate=60`,
-          'X-EchoFlow-Health': healthStatus,
-          'Access-Control-Allow-Origin': origin || '*',
+          'X-EchoFlow-Health': 'healthy',
+          ...corsHeaders,
+          ...securityHeaders,
         },
       });
     }
@@ -236,18 +240,22 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(responseData, {
       headers: {
         'Cache-Control': `public, max-age=${getCacheTtl(resourceType)}, stale-while-revalidate=60`,
-        'X-EchoFlow-Health': healthStatus,
-        'Access-Control-Allow-Origin': origin || '*',
+        'X-EchoFlow-Health': 'healthy',
+        ...corsHeaders,
+        ...securityHeaders,
       },
     });
   } catch (error) {
+    const isDev = process.env.NODE_ENV === 'development';
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    console.error('EchoFlow API error:', errorMessage);
+    if (isDev) {
+      console.error('EchoFlow API error:', errorMessage);
+    }
     return NextResponse.json(
       {
         error: 'Internal server error',
         code: 'INTERNAL_ERROR',
-        ...(process.env.NODE_ENV === 'development' && { details: errorMessage }),
+        ...(isDev && { details: errorMessage }),
       },
       { status: 500, headers: buildCorsHeaders(origin) }
     );
@@ -258,20 +266,23 @@ export async function OPTIONS(request: NextRequest) {
   const origin = request.headers.get('origin');
   const clientKey = request.headers.get(API_KEY_HEADER);
   const hasValidKey = FLOW_KEY && clientKey === FLOW_KEY;
-  const healthStatus = FLOW_KEY ? 'healthy' : 'disabled';
 
   if (!isOriginAllowed(origin) && !hasValidKey) {
     return new NextResponse(null, { status: 403 });
   }
 
+  const corsHeaders = buildCorsHeaders(origin);
+
   return new NextResponse(null, {
     status: 200,
     headers: {
-      'Access-Control-Allow-Origin': origin || '*',
+      ...corsHeaders,
       'Access-Control-Allow-Methods': 'GET, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-EchoFlow-Key',
       'Cache-Control': 'public, max-age=86400',
-      'X-EchoFlow-Health': healthStatus,
+      'X-EchoFlow-Health': 'healthy',
+      'Vary': 'Origin',
+      'X-Content-Type-Options': 'nosniff',
     },
   });
 }

--- a/src/app/api/echoflow/[...path]/route.ts
+++ b/src/app/api/echoflow/[...path]/route.ts
@@ -178,6 +178,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     if (decoded.includes('..')) {
       return undefined;
     }
+    if (/%(?![0-9a-fA-F]{2})/.test(decoded)) {
+      return undefined;
+    }
     if (decoded.length > MAX_DETAIL_ID_LENGTH) {
       return undefined;
     }

--- a/src/app/api/echoflow/resolvers.ts
+++ b/src/app/api/echoflow/resolvers.ts
@@ -108,12 +108,9 @@ async function getSupabaseHistory(): Promise<
   supabaseHistoryTimestamp = Date.now();
 
   for (const [key, history] of historyMap) {
-    const [, entryId] = key.split(':');
-    if (!entryId) continue;
-
-    const existing = supabaseHistoryCache.get(entryId);
+    const existing = supabaseHistoryCache.get(key);
     if (!existing || new Date(history.updatedAt) > new Date(existing.updatedAt)) {
-      supabaseHistoryCache.set(entryId, {
+      supabaseHistoryCache.set(key, {
         updatedAt: history.updatedAt,
         message: history.message,
         actionId: history.actionId,
@@ -127,11 +124,12 @@ async function getSupabaseHistory(): Promise<
 }
 
 async function getMergedUpdateTime(
+  entityType: string,
   itemName: string
 ): Promise<{ date: string; description?: string } | undefined> {
   const wikiUpdate = getUpdateLookup().get(itemName);
   const supabaseHistory = await getSupabaseHistory();
-  const supabaseUpdate = supabaseHistory.get(itemName);
+  const supabaseUpdate = supabaseHistory.get(`${entityType}:${itemName}`);
 
   if (!wikiUpdate && !supabaseUpdate) return undefined;
   if (!wikiUpdate && supabaseUpdate) {
@@ -192,13 +190,16 @@ function recordToArray<T extends object>(
   }));
 }
 
-function findByKey<T>(record: Record<string, T>, key: string): (T & { name: string }) | null {
-  let decodedKey: string;
+function safeDecode(value: string): string {
   try {
-    decodedKey = decodeURIComponent(key);
+    return decodeURIComponent(value);
   } catch {
-    decodedKey = key;
+    return value;
   }
+}
+
+function findByKey<T>(record: Record<string, T>, key: string): (T & { name: string }) | null {
+  const decodedKey = safeDecode(key);
   const item = record[decodedKey];
   if (!item) return null;
   return { ...item, name: decodedKey };
@@ -265,12 +266,12 @@ export const resolvers: Record<string, PathResolver> = {
     },
     detail: async (id: string) => {
       const charactersRecord = GameDataManager.getCharacters();
-      const decodedId = decodeURIComponent(id);
+      const decodedId = safeDecode(id);
       const character = charactersRecord[decodedId];
       if (!character) return null;
 
       const relations = getCharacterRelation(decodedId);
-      const updateInfo = await getMergedUpdateTime(decodedId);
+      const updateInfo = await getMergedUpdateTime('characters', decodedId);
 
       return createDetailResult(
         {
@@ -332,10 +333,10 @@ export const resolvers: Record<string, PathResolver> = {
       return createListResult(cardsList, 'Card', '/cards', true);
     },
     detail: async (id: string) => {
-      const decodedId = decodeURIComponent(id);
+      const decodedId = safeDecode(id);
       const card = cards[decodedId];
       if (!card) return null;
-      const updateInfo = await getMergedUpdateTime(decodedId);
+      const updateInfo = await getMergedUpdateTime('cards', decodedId);
       return createDetailResult(
         { ...card, id: decodedId },
         'Card',
@@ -358,7 +359,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const item = findByKey(items, id);
       if (!item) return null;
-      const updateInfo = await getMergedUpdateTime(item.name);
+      const updateInfo = await getMergedUpdateTime('items', item.name);
       return createDetailResult(item, 'Item', `/items/${item.name}`, updateInfo?.date);
     },
     fullData: () => {
@@ -376,7 +377,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const entity = findByKey(entities, id);
       if (!entity) return null;
-      const updateInfo = await getMergedUpdateTime(entity.name);
+      const updateInfo = await getMergedUpdateTime('entities', entity.name);
       return createDetailResult(entity, 'Entity', `/entities/${entity.name}`, updateInfo?.date);
     },
     fullData: () => {
@@ -394,7 +395,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const buff = findByKey(buffs, id);
       if (!buff) return null;
-      const updateInfo = await getMergedUpdateTime(buff.name);
+      const updateInfo = await getMergedUpdateTime('buffs', buff.name);
       return createDetailResult(buff, 'Buff', `/buffs/${buff.name}`, updateInfo?.date);
     },
     fullData: () => {
@@ -412,7 +413,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const map = findByKey(maps, id);
       if (!map) return null;
-      const updateInfo = await getMergedUpdateTime(map.name);
+      const updateInfo = await getMergedUpdateTime('maps', map.name);
       return createDetailResult(map, 'Map', `/maps/${map.name}`, updateInfo?.date);
     },
     fullData: () => {
@@ -430,7 +431,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const fixture = findByKey(fixtures, id);
       if (!fixture) return null;
-      const updateInfo = await getMergedUpdateTime(fixture.name);
+      const updateInfo = await getMergedUpdateTime('fixtures', fixture.name);
       return createDetailResult(fixture, 'Fixture', `/fixtures/${fixture.name}`, updateInfo?.date);
     },
     fullData: () => {
@@ -448,7 +449,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const mode = findByKey(modes, id);
       if (!mode) return null;
-      const updateInfo = await getMergedUpdateTime(mode.name);
+      const updateInfo = await getMergedUpdateTime('modes', mode.name);
       return createDetailResult(mode, 'Mode', `/modes/${mode.name}`, updateInfo?.date);
     },
     fullData: () => {
@@ -466,7 +467,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const achievement = findByKey(achievements, id);
       if (!achievement) return null;
-      const updateInfo = await getMergedUpdateTime(achievement.name);
+      const updateInfo = await getMergedUpdateTime('achievements', achievement.name);
       return createDetailResult(
         achievement,
         'Achievement',
@@ -503,7 +504,7 @@ export const resolvers: Record<string, PathResolver> = {
         factionId = 'mouse';
       }
       if (!skill) return null;
-      const updateInfo = await getMergedUpdateTime(decodedId);
+      const updateInfo = await getMergedUpdateTime('specialSkills', decodedId);
       return createDetailResult(
         { ...skill, name: decodedId, factionId },
         'SpecialSkill',
@@ -565,7 +566,7 @@ export const resolvers: Record<string, PathResolver> = {
     detail: async (id: string) => {
       const group = findByKey(itemGroups, id);
       if (!group) return null;
-      const updateInfo = await getMergedUpdateTime(group.name);
+      const updateInfo = await getMergedUpdateTime('itemGroups', group.name);
       return createDetailResult(group, 'ItemGroup', `/itemGroups/${group.name}`, updateInfo?.date);
     },
     fullData: () => {

--- a/src/app/api/echoflow/resolvers.ts
+++ b/src/app/api/echoflow/resolvers.ts
@@ -33,11 +33,31 @@ import {
 } from '@/data';
 
 let updateLookup: Map<string, { date: string; description?: string }> | null = null;
+let updateLookupTimestamp: number | null = null;
+let supabaseHistoryCache: Map<
+  string,
+  {
+    updatedAt: string;
+    message: string | null;
+    actionId: string;
+    createdBy: string | null;
+    status: string;
+  }
+> | null = null;
+let supabaseHistoryTimestamp: number | null = null;
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+function isCacheExpired(timestamp: number | null): boolean {
+  if (!timestamp) return true;
+  return Date.now() - timestamp > CACHE_TTL_MS;
+}
 
 function getUpdateLookup(): Map<string, { date: string; description?: string }> {
-  if (updateLookup) return updateLookup;
+  if (updateLookup && !isCacheExpired(updateLookupTimestamp)) return updateLookup;
 
   updateLookup = new Map();
+  updateLookupTimestamp = Date.now();
   for (const yearData of wikiHistoryData) {
     for (const event of yearData.events) {
       const changes = event.details.data?.changes || [];
@@ -45,12 +65,12 @@ function getUpdateLookup(): Map<string, { date: string; description?: string }> 
       const allChanges = [
         ...changes.map((c) => ({
           change: c,
-          date: `${yearData.year}.${event.date.split('-')[0]}`,
+          date: `${yearData.year}-${event.date}`,
         })),
         ...batchChanges.flatMap((batch) =>
           batch.changes.map((c) => ({
             change: c,
-            date: `${yearData.year}.${event.date.split('-')[0]}`,
+            date: `${yearData.year}-${event.date}`,
           }))
         ),
       ];
@@ -66,8 +86,72 @@ function getUpdateLookup(): Map<string, { date: string; description?: string }> 
   return updateLookup;
 }
 
-function getItemUpdateTime(itemName: string): { date: string; description?: string } | undefined {
-  return getUpdateLookup().get(itemName);
+async function getSupabaseHistory(): Promise<
+  Map<
+    string,
+    {
+      updatedAt: string;
+      message: string | null;
+      actionId: string;
+      createdBy: string | null;
+      status: string;
+    }
+  >
+> {
+  if (supabaseHistoryCache && !isCacheExpired(supabaseHistoryTimestamp)) {
+    return supabaseHistoryCache;
+  }
+
+  const { getEntityUpdateHistory } = await import('@/lib/gameData/publicActions');
+  const historyMap = await getEntityUpdateHistory();
+  supabaseHistoryCache = new Map();
+  supabaseHistoryTimestamp = Date.now();
+
+  for (const [key, history] of historyMap) {
+    const [, entryId] = key.split(':');
+    if (!entryId) continue;
+
+    const existing = supabaseHistoryCache.get(entryId);
+    if (!existing || new Date(history.updatedAt) > new Date(existing.updatedAt)) {
+      supabaseHistoryCache.set(entryId, {
+        updatedAt: history.updatedAt,
+        message: history.message,
+        actionId: history.actionId,
+        createdBy: history.createdBy,
+        status: history.status,
+      });
+    }
+  }
+
+  return supabaseHistoryCache;
+}
+
+async function getMergedUpdateTime(
+  itemName: string
+): Promise<{ date: string; description?: string } | undefined> {
+  const wikiUpdate = getUpdateLookup().get(itemName);
+  const supabaseHistory = await getSupabaseHistory();
+  const supabaseUpdate = supabaseHistory.get(itemName);
+
+  if (!wikiUpdate && !supabaseUpdate) return undefined;
+  if (!wikiUpdate && supabaseUpdate) {
+    const result: { date: string; description?: string } = { date: supabaseUpdate.updatedAt };
+    if (supabaseUpdate.message) result.description = supabaseUpdate.message;
+    return result;
+  }
+  if (wikiUpdate && !supabaseUpdate) return wikiUpdate;
+  if (wikiUpdate && supabaseUpdate) {
+    const wikiDate = new Date(wikiUpdate.date);
+    const supabaseDate = new Date(supabaseUpdate.updatedAt);
+
+    if (supabaseDate > wikiDate) {
+      const result: { date: string; description?: string } = { date: supabaseUpdate.updatedAt };
+      if (supabaseUpdate.message) result.description = supabaseUpdate.message;
+      return result;
+    }
+    return wikiUpdate;
+  }
+  return undefined;
 }
 
 export type ResolverResult = {
@@ -109,7 +193,12 @@ function recordToArray<T extends object>(
 }
 
 function findByKey<T>(record: Record<string, T>, key: string): (T & { name: string }) | null {
-  const decodedKey = decodeURIComponent(key);
+  let decodedKey: string;
+  try {
+    decodedKey = decodeURIComponent(key);
+  } catch {
+    decodedKey = key;
+  }
   const item = record[decodedKey];
   if (!item) return null;
   return { ...item, name: decodedKey };
@@ -174,14 +263,14 @@ export const resolvers: Record<string, PathResolver> = {
       const charactersList = recordToArray(charactersRecord, 'id');
       return createListResult(charactersList, 'Character', '/characters', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const charactersRecord = GameDataManager.getCharacters();
       const decodedId = decodeURIComponent(id);
       const character = charactersRecord[decodedId];
       if (!character) return null;
 
       const relations = getCharacterRelation(decodedId);
-      const updateInfo = getItemUpdateTime(decodedId);
+      const updateInfo = await getMergedUpdateTime(decodedId);
 
       return createDetailResult(
         {
@@ -204,7 +293,7 @@ export const resolvers: Record<string, PathResolver> = {
               : undefined,
         },
         'Character',
-        `/characters/${id}`,
+        `/characters/${decodedId}`,
         updateInfo?.date
       );
     },
@@ -242,15 +331,15 @@ export const resolvers: Record<string, PathResolver> = {
       const cardsList = recordToArray(cards, 'id');
       return createListResult(cardsList, 'Card', '/cards', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const decodedId = decodeURIComponent(id);
       const card = cards[decodedId];
       if (!card) return null;
-      const updateInfo = getItemUpdateTime(decodedId);
+      const updateInfo = await getMergedUpdateTime(decodedId);
       return createDetailResult(
         { ...card, id: decodedId },
         'Card',
-        `/cards/${id}`,
+        `/cards/${decodedId}`,
         updateInfo?.date
       );
     },
@@ -266,11 +355,11 @@ export const resolvers: Record<string, PathResolver> = {
       const itemsList = recordToArray(items, 'name');
       return createListResult(itemsList, 'Item', '/items', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const item = findByKey(items, id);
       if (!item) return null;
-      const updateInfo = getItemUpdateTime(item.name);
-      return createDetailResult(item, 'Item', `/items/${id}`, updateInfo?.date);
+      const updateInfo = await getMergedUpdateTime(item.name);
+      return createDetailResult(item, 'Item', `/items/${item.name}`, updateInfo?.date);
     },
     fullData: () => {
       const fullItems = recordToArray(items, 'name');
@@ -284,11 +373,11 @@ export const resolvers: Record<string, PathResolver> = {
       const entitiesList = recordToArray(entities, 'name');
       return createListResult(entitiesList, 'Entity', '/entities', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const entity = findByKey(entities, id);
       if (!entity) return null;
-      const updateInfo = getItemUpdateTime(entity.name);
-      return createDetailResult(entity, 'Entity', `/entities/${id}`, updateInfo?.date);
+      const updateInfo = await getMergedUpdateTime(entity.name);
+      return createDetailResult(entity, 'Entity', `/entities/${entity.name}`, updateInfo?.date);
     },
     fullData: () => {
       const fullEntities = recordToArray(entities, 'name');
@@ -302,11 +391,11 @@ export const resolvers: Record<string, PathResolver> = {
       const buffsList = recordToArray(buffs, 'name');
       return createListResult(buffsList, 'Buff', '/buffs', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const buff = findByKey(buffs, id);
       if (!buff) return null;
-      const updateInfo = getItemUpdateTime(buff.name);
-      return createDetailResult(buff, 'Buff', `/buffs/${id}`, updateInfo?.date);
+      const updateInfo = await getMergedUpdateTime(buff.name);
+      return createDetailResult(buff, 'Buff', `/buffs/${buff.name}`, updateInfo?.date);
     },
     fullData: () => {
       const fullBuffs = recordToArray(buffs, 'name');
@@ -320,11 +409,11 @@ export const resolvers: Record<string, PathResolver> = {
       const mapsList = recordToArray(maps, 'name');
       return createListResult(mapsList, 'Map', '/maps', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const map = findByKey(maps, id);
       if (!map) return null;
-      const updateInfo = getItemUpdateTime(map.name);
-      return createDetailResult(map, 'Map', `/maps/${id}`, updateInfo?.date);
+      const updateInfo = await getMergedUpdateTime(map.name);
+      return createDetailResult(map, 'Map', `/maps/${map.name}`, updateInfo?.date);
     },
     fullData: () => {
       const fullMaps = recordToArray(maps, 'name');
@@ -338,11 +427,11 @@ export const resolvers: Record<string, PathResolver> = {
       const fixturesList = recordToArray(fixtures, 'name');
       return createListResult(fixturesList, 'Fixture', '/fixtures', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const fixture = findByKey(fixtures, id);
       if (!fixture) return null;
-      const updateInfo = getItemUpdateTime(fixture.name);
-      return createDetailResult(fixture, 'Fixture', `/fixtures/${id}`, updateInfo?.date);
+      const updateInfo = await getMergedUpdateTime(fixture.name);
+      return createDetailResult(fixture, 'Fixture', `/fixtures/${fixture.name}`, updateInfo?.date);
     },
     fullData: () => {
       const fullFixtures = recordToArray(fixtures, 'name');
@@ -356,11 +445,11 @@ export const resolvers: Record<string, PathResolver> = {
       const modesList = recordToArray(modes, 'name');
       return createListResult(modesList, 'Mode', '/modes', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const mode = findByKey(modes, id);
       if (!mode) return null;
-      const updateInfo = getItemUpdateTime(mode.name);
-      return createDetailResult(mode, 'Mode', `/modes/${id}`, updateInfo?.date);
+      const updateInfo = await getMergedUpdateTime(mode.name);
+      return createDetailResult(mode, 'Mode', `/modes/${mode.name}`, updateInfo?.date);
     },
     fullData: () => {
       const fullModes = recordToArray(modes, 'name');
@@ -374,14 +463,14 @@ export const resolvers: Record<string, PathResolver> = {
       const achievementsList = recordToArray(achievements, 'name');
       return createListResult(achievementsList, 'Achievement', '/achievements', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const achievement = findByKey(achievements, id);
       if (!achievement) return null;
-      const updateInfo = getItemUpdateTime(achievement.name);
+      const updateInfo = await getMergedUpdateTime(achievement.name);
       return createDetailResult(
         achievement,
         'Achievement',
-        `/achievements/${id}`,
+        `/achievements/${achievement.name}`,
         updateInfo?.date
       );
     },
@@ -405,7 +494,7 @@ export const resolvers: Record<string, PathResolver> = {
       const allSkills = [...catSkillsList, ...mouseSkillsList];
       return createListResult(allSkills, 'SpecialSkill', '/special-skills', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const decodedId = decodeURIComponent(id);
       let skill = specialSkills.cat[decodedId];
       let factionId: 'cat' | 'mouse' = 'cat';
@@ -414,11 +503,11 @@ export const resolvers: Record<string, PathResolver> = {
         factionId = 'mouse';
       }
       if (!skill) return null;
-      const updateInfo = getItemUpdateTime(decodedId);
+      const updateInfo = await getMergedUpdateTime(decodedId);
       return createDetailResult(
         { ...skill, name: decodedId, factionId },
         'SpecialSkill',
-        `/special-skills/${id}`,
+        `/special-skills/${decodedId}`,
         updateInfo?.date
       );
     },
@@ -454,7 +543,7 @@ export const resolvers: Record<string, PathResolver> = {
       const factionsWithCharacters = GameDataManager.getFactionsWithCharacters(characters);
       const faction = factionsWithCharacters[decodedId];
       if (!faction) return null;
-      return createDetailResult({ ...faction, id: decodedId }, 'Faction', `/factions/${id}`);
+      return createDetailResult({ ...faction, id: decodedId }, 'Faction', `/factions/${decodedId}`);
     },
     fullData: () => {
       const characters = GameDataManager.getCharacters();
@@ -473,11 +562,11 @@ export const resolvers: Record<string, PathResolver> = {
       const groupsList = recordToArray(itemGroups, 'name');
       return createListResult(groupsList, 'ItemGroup', '/itemGroups', true);
     },
-    detail: (id: string) => {
+    detail: async (id: string) => {
       const group = findByKey(itemGroups, id);
       if (!group) return null;
-      const updateInfo = getItemUpdateTime(group.name);
-      return createDetailResult(group, 'ItemGroup', `/itemGroups/${id}`, updateInfo?.date);
+      const updateInfo = await getMergedUpdateTime(group.name);
+      return createDetailResult(group, 'ItemGroup', `/itemGroups/${group.name}`, updateInfo?.date);
     },
     fullData: () => {
       const fullItemGroups = recordToArray(itemGroups, 'name');
@@ -786,8 +875,8 @@ export async function resolvePath(
   if (!resolver) return null;
 
   if (detailId && resolver.detail) {
-    const result = resolver.detail(detailId);
-    return result instanceof Promise ? await result : result;
+    const result = await resolver.detail(detailId);
+    return result;
   }
 
   if (fullData && resolver.fullData) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,6 +15,8 @@ export const env = createEnv({
     // Supabase
     SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 
+    FLOWKEY: z.string().optional(),
+
     // Debug
     CHAT_DEBUG_LOG: binaryFlag,
 

--- a/src/hooks/usePublicGameDataActions.test.tsx
+++ b/src/hooks/usePublicGameDataActions.test.tsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from '@testing-library/react';
 
 import { GameDataManager } from '@/lib/dataManager';
+import { PublicActionRow } from '@/lib/gameData/publicActionsTypes';
 import { characters } from '@/data';
 
 import { usePublicGameDataActions } from './usePublicGameDataActions';
@@ -11,13 +12,6 @@ jest.mock('@/env', () => ({
     NEXT_PUBLIC_SUPABASE_ANON_KEY: 'test-anon-key',
   },
 }));
-
-type PublicActionRow = {
-  id: string;
-  entity_type: string;
-  entry: unknown;
-  created_at: string;
-};
 
 const cloneCharacters = () => structuredClone(characters);
 
@@ -69,6 +63,10 @@ describe('usePublicGameDataActions', () => {
             },
           ],
         },
+        status: 'approved',
+        message: null,
+        reviewed_at: null,
+        created_by: null,
       },
     ];
 
@@ -112,6 +110,10 @@ describe('usePublicGameDataActions', () => {
             },
           ],
         },
+        status: 'approved',
+        message: null,
+        reviewed_at: null,
+        created_by: null,
       },
     ];
 

--- a/src/lib/gameData/publicActions.ts
+++ b/src/lib/gameData/publicActions.ts
@@ -179,6 +179,55 @@ function applyPublicGameDataActionsToServerData(actions: PublicActionRow[]): voi
   }
 }
 
+export type EntityUpdateHistory = {
+  updatedAt: string;
+  actionId: string;
+  createdBy: string | null;
+  status: string;
+  message: string | null;
+  reviewedAt: string | null;
+  affectedPath: string;
+};
+
+export async function getEntityUpdateHistory(): Promise<Map<string, EntityUpdateHistory>> {
+  const actions = await getPublicGameDataActions();
+  const historyMap = new Map<string, EntityUpdateHistory>();
+
+  for (const action of actions) {
+    if (action.status !== 'approved' && action.status !== 'synced') continue;
+
+    const entries = parseEntries(action.entry);
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      const act = entry as { path?: string };
+
+      if (!act.path) continue;
+
+      const pathParts = act.path.split('.').filter(Boolean);
+      if (pathParts.length === 0) continue;
+
+      const entryId = pathParts[0];
+      if (!entryId) continue;
+      const historyKey = `${action.entity_type}:${entryId}`;
+
+      const existing = historyMap.get(historyKey);
+      if (!existing || new Date(action.created_at) > new Date(existing.updatedAt)) {
+        historyMap.set(historyKey, {
+          updatedAt: action.created_at,
+          actionId: action.id,
+          createdBy: action.created_by ?? null,
+          status: action.status,
+          message: action.message ?? null,
+          reviewedAt: action.reviewed_at ?? null,
+          affectedPath: act.path,
+        });
+      }
+    }
+  }
+
+  return historyMap;
+}
+
 export async function getPublicGameDataActions(): Promise<PublicActionRow[]> {
   if (env.NEXT_PUBLIC_DISABLE_ARTICLES === '1' || !env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     return [];
@@ -189,7 +238,7 @@ export async function getPublicGameDataActions(): Promise<PublicActionRow[]> {
     async () => {
       const { data, error } = await supabaseServerPublic
         .from('game_data_actions')
-        .select('id, entity_type, entry, created_at')
+        .select('id, entity_type, entry, created_at, status, message, reviewed_at, created_by')
         .eq('is_public', true)
         .order('created_at', { ascending: true });
 

--- a/src/lib/gameData/publicActions.ts
+++ b/src/lib/gameData/publicActions.ts
@@ -189,6 +189,28 @@ export type EntityUpdateHistory = {
   affectedPath: string;
 };
 
+function extractActionPaths(entry: ActionHistoryEntry): string[] {
+  if (Array.isArray(entry)) {
+    const paths: string[] = [];
+    for (const action of entry) {
+      if (action.path) paths.push(action.path);
+    }
+    return paths;
+  }
+  return entry.path ? [entry.path] : [];
+}
+
+function extractEntryId(entityType: string, path: string): string | undefined {
+  const pathParts = path.split('.').filter(Boolean);
+  if (pathParts.length === 0) return undefined;
+
+  if (entityType === 'specialSkills') {
+    return pathParts.length >= 2 ? pathParts[1] : undefined;
+  }
+
+  return pathParts[0];
+}
+
 export async function getEntityUpdateHistory(): Promise<Map<string, EntityUpdateHistory>> {
   const actions = await getPublicGameDataActions();
   const historyMap = new Map<string, EntityUpdateHistory>();
@@ -198,29 +220,25 @@ export async function getEntityUpdateHistory(): Promise<Map<string, EntityUpdate
 
     const entries = parseEntries(action.entry);
     for (const entry of entries) {
-      if (!entry || typeof entry !== 'object') continue;
-      const act = entry as { path?: string };
+      const paths = extractActionPaths(entry);
+      for (const path of paths) {
+        const entryId = extractEntryId(action.entity_type, path);
+        if (!entryId) continue;
 
-      if (!act.path) continue;
+        const historyKey = `${action.entity_type}:${entryId}`;
 
-      const pathParts = act.path.split('.').filter(Boolean);
-      if (pathParts.length === 0) continue;
-
-      const entryId = pathParts[0];
-      if (!entryId) continue;
-      const historyKey = `${action.entity_type}:${entryId}`;
-
-      const existing = historyMap.get(historyKey);
-      if (!existing || new Date(action.created_at) > new Date(existing.updatedAt)) {
-        historyMap.set(historyKey, {
-          updatedAt: action.created_at,
-          actionId: action.id,
-          createdBy: action.created_by ?? null,
-          status: action.status,
-          message: action.message ?? null,
-          reviewedAt: action.reviewed_at ?? null,
-          affectedPath: act.path,
-        });
+        const existing = historyMap.get(historyKey);
+        if (!existing || new Date(action.created_at) > new Date(existing.updatedAt)) {
+          historyMap.set(historyKey, {
+            updatedAt: action.created_at,
+            actionId: action.id,
+            createdBy: action.created_by ?? null,
+            status: action.status,
+            message: action.message ?? null,
+            reviewedAt: action.reviewed_at ?? null,
+            affectedPath: path,
+          });
+        }
       }
     }
   }

--- a/src/lib/gameData/publicActionsTypes.ts
+++ b/src/lib/gameData/publicActionsTypes.ts
@@ -13,4 +13,8 @@ export type PublicActionRow = {
    */
   entry: unknown;
   created_at: string;
+  status: string;
+  message: string | null;
+  reviewed_at: string | null;
+  created_by: string | null;
 };


### PR DESCRIPTION
修复了有关于 EchoFlow API 的若干安全和逻辑问题，具体如下：

- 问题：isOriginAllowed 未校验子域名格式，攻击者可通过构建复杂的雷同域名绕过验证
  文件：src/app/api/echoflow/[...path]/route.ts
  修复：正则判严，加入特殊符

- 问题：updateLookup 和 supabaseHistoryCache 缓存不过期导致内存开销无法释放
  文件：src/app/api/echoflow/resolvers.ts
  修复：添加过期 TTL

- 问题：差分增量数据时少写一个函数导致对外暴露的数据永远是没有实时性的老数据
  文件：src/lib/gameData/publicActions.ts, src/lib/gameData/publicActionsTypes.ts, src/app/api/echoflow/resolvers.ts
  修复：扩展查询字段，新增 getEntityUpdateHistory 函数

- 问题：Detail ID 校验太严，过滤了所有非 ASCII 字符，导致中文的实体 ID 无法使用
  文件：src/app/api/echoflow/[...path]/route.ts
  修复：按需减少正则判断

- 问题：findByKey 缺少异常处理
  文件：src/app/api/echoflow/resolvers.ts
  修复：添加 try-catch